### PR TITLE
Update nf-core schema to use path instead of file-path for nf-validation

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -25,7 +25,7 @@
                     "type": "string",
                     "description": "Path to remote file to download and use.",
                     "help_text": "Path to a remote file to use within the pipeline. This mimics a remote set of files such as reference data that may need to be retrieved prior to analysis. By default this is not specified and the test is not ran, add a remote file using standard Nextflow filenaming to pull a file from your storage (e.g. an S3 bucket or shared storage).",
-                    "format": "file-path"
+                    "format": "path"
                 },
                 "outdir": {
                     "type": "string",


### PR DESCRIPTION
Updates the nf-core schema to use a path instead of file-path for inputs in case a user wanted to download a directory.