### PR TITLE
refactor: rewrite nf-tests to use assertAll and precise naming

### DIFF
--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -13,11 +13,13 @@ nextflow_pipeline{
         }
 
         then {
-            assert workflow.success
-            assert workflow.trace.tasks().size()     == 14
-            assert workflow.trace.succeeded().size() == 13
-            assert workflow.trace.failed().size()    == 1
-            assert snapshot(workflow, path(params.outdir).list()).match()
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.trace.tasks().size()     == 14 },
+                { assert workflow.trace.succeeded().size() == 13 },
+                { assert workflow.trace.failed().size()    == 1 },
+                { assert snapshot(workflow, path(params.outdir).list()).match() }
+            )
         }
 
     }
@@ -33,11 +35,13 @@ nextflow_pipeline{
         }
 
         then {
-            assert workflow.success
-            assert workflow.trace.tasks().size()     == 13
-            assert workflow.trace.succeeded().size() == 12
-            assert workflow.trace.failed().size()    == 1
-            assert snapshot(workflow, path(params.outdir).list()).match()
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.trace.tasks().size()     == 13 },
+                { assert workflow.trace.succeeded().size() == 12 },
+                { assert workflow.trace.failed().size()    == 1 },
+                { assert snapshot(workflow, path(params.outdir).list()).match() }
+            )
         }
 
     }
@@ -54,11 +58,13 @@ nextflow_pipeline{
         }
 
         then {
-            assert workflow.success
-            assert workflow.trace.tasks().size()     == 1
-            assert workflow.trace.succeeded().size() == 1
-            assert workflow.trace.failed().size()    == 0
-            assert snapshot(workflow, path(params.outdir).list()).match()
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.trace.tasks().size()     == 1 },
+                { assert workflow.trace.succeeded().size() == 1 },
+                { assert workflow.trace.failed().size()    == 0 },
+                { assert snapshot(workflow, path(params.outdir).list()).match() }
+            )
         }
 
     }
@@ -73,11 +79,13 @@ nextflow_pipeline{
         }
 
         then {
-            assert workflow.success
-            assert workflow.trace.tasks().size()     == 14
-            assert workflow.trace.succeeded().size() == 13
-            assert workflow.trace.failed().size()    == 1
-            assert snapshot(workflow, path("${launchDir}/output").list()).match()
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.trace.tasks().size()     == 14 },
+                { assert workflow.trace.succeeded().size() == 13 },
+                { assert workflow.trace.failed().size()    == 1 },
+                { assert snapshot(workflow, path("${launchDir}/output").list()).match() }
+            )
         }
 
     }

--- a/tests/main.test_bin_script.test
+++ b/tests/main.test_bin_script.test
@@ -4,11 +4,13 @@ nextflow_process {
     script "main.nf"
     process "TEST_BIN_SCRIPT"
 
-    test("Should run without failures") {
+    test("TEST_BIN_SCRIPT") {
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_create_file.nf.test
+++ b/tests/main.test_create_file.nf.test
@@ -4,11 +4,13 @@ nextflow_process {
     script "main.nf"
     process "TEST_CREATE_FILE"
 
-    test("Should run without failures") {
+    test("TEST_CREATE_FILE") {
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(                
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_create_file.nf.test.snap
+++ b/tests/main.test_create_file.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Should run without failures": {
+    "TEST_CREATE_FILE": {
         "content": [
             {
                 "0": [
@@ -10,6 +10,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-04T11:56:41.550158"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-18T17:19:44.512229"
     }
 }

--- a/tests/main.test_create_folder.nf.test
+++ b/tests/main.test_create_folder.nf.test
@@ -4,11 +4,13 @@ nextflow_process {
     script "main.nf"
     process "TEST_CREATE_FOLDER"
 
-    test("Should run without failures") {
+    test("TEST_CREATE_FOLDER") {
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_create_folder.nf.test.snap
+++ b/tests/main.test_create_folder.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Should run without failures": {
+    "TEST_CREATE_FOLDER": {
         "content": [
             {
                 "0": [
@@ -16,6 +16,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-04T11:56:39.696681"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-18T17:19:42.631931"
     }
 }

--- a/tests/main.test_ignore_fail.test
+++ b/tests/main.test_ignore_fail.test
@@ -4,13 +4,15 @@ nextflow_process {
     script "main.nf"
     process "TEST_IGNORED_FAIL"
 
-    test("Should run without failures") {
+    test("TEST_IGNORED_FAIL") {
 
         then {
-            assert process.success
-            assert snapshot(process).match()
-            assert process.trace.failed().size() == 1
-            assert process.trace.succeeded().size() == 0
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process).match() },
+                { assert process.trace.failed().size() == 1 },
+                { assert process.trace.succeeded().size() == 0 }
+            )
         }
 
     }

--- a/tests/main.test_input.nf.test
+++ b/tests/main.test_input.nf.test
@@ -4,7 +4,7 @@ nextflow_process {
     script "main.nf"
     process "TEST_INPUT"
 
-    test("Should run without failures") {
+    test("TEST_INPUT") {
 
         when {
             process {
@@ -15,8 +15,10 @@ nextflow_process {
         }
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_input.nf.test.snap
+++ b/tests/main.test_input.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Should run without failures": {
+    "TEST_INPUT": {
         "content": [
             {
                 "0": [
@@ -7,6 +7,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-04T11:56:21.166077"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-18T17:19:23.807701"
     }
 }

--- a/tests/main.test_mv_file.nf.test
+++ b/tests/main.test_mv_file.nf.test
@@ -4,11 +4,13 @@ nextflow_process {
     script "main.nf"
     process "TEST_MV_FILE"
 
-    test("Should run without failures") {
+    test("TEST_MV_FILE") {
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_mv_file.nf.test.snap
+++ b/tests/main.test_mv_file.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Should run without failures": {
+    "TEST_MV_FILE": {
         "content": [
             {
                 "0": [
@@ -7,6 +7,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-04T11:56:19.102784"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-18T17:19:21.768791"
     }
 }

--- a/tests/main.test_mv_folder_contents.nf.test
+++ b/tests/main.test_mv_folder_contents.nf.test
@@ -4,11 +4,13 @@ nextflow_process {
     script "main.nf"
     process "TEST_MV_FOLDER_CONTENTS"
 
-    test("Should run without failures") {
+    test("TEST_MV_FOLDER_CONTENTS") {
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_mv_folder_contents.nf.test.snap
+++ b/tests/main.test_mv_folder_contents.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Should run without failures": {
+    "TEST_MV_FOLDER_CONTENTS": {
         "content": [
             {
                 "0": [
@@ -14,6 +14,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-04T12:19:57.98459"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-18T17:19:19.746587"
     }
 }

--- a/tests/main.test_pass_file.nf.test
+++ b/tests/main.test_pass_file.nf.test
@@ -4,7 +4,7 @@ nextflow_process {
     script "main.nf"
     process "TEST_PASS_FILE"
 
-    test("Should run without failures") {
+    test("TEST_PASS_FILE") {
 
         when {
             process {
@@ -15,8 +15,10 @@ nextflow_process {
         }
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_pass_file.nf.test.snap
+++ b/tests/main.test_pass_file.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Should run without failures": {
+    "TEST_PASS_FILE": {
         "content": [
             {
                 "0": [
@@ -10,6 +10,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-04T11:56:24.966198"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-18T17:19:28.094518"
     }
 }

--- a/tests/main.test_pass_folder.nf.test
+++ b/tests/main.test_pass_folder.nf.test
@@ -4,7 +4,7 @@ nextflow_process {
     script "main.nf"
     process "TEST_PASS_FOLDER"
 
-    test("Should run without failures") {
+    test("TEST_PASS_FOLDER") {
 
         when {
             process {
@@ -19,8 +19,10 @@ nextflow_process {
         }
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_pass_folder.nf.test.snap
+++ b/tests/main.test_pass_folder.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Should run without failures": {
+    "TEST_PASS_FOLDER": {
         "content": [
             {
                 "0": [
@@ -14,6 +14,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-04T12:19:55.945452"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-18T17:19:17.775111"
     }
 }

--- a/tests/main.test_publish_file.nf.test
+++ b/tests/main.test_publish_file.nf.test
@@ -4,11 +4,13 @@ nextflow_process {
     script "main.nf"
     process "TEST_PUBLISH_FILE"
 
-    test("Should run without failures") {
+    test("TEST_PUBLISH_FILE") {
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_publish_file.nf.test.snap
+++ b/tests/main.test_publish_file.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Should run without failures": {
+    "TEST_PUBLISH_FILE": {
         "content": [
             {
                 "0": [
@@ -7,6 +7,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-04T11:56:23.047403"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-18T17:19:25.923767"
     }
 }

--- a/tests/main.test_publish_folder.nf.test
+++ b/tests/main.test_publish_folder.nf.test
@@ -4,11 +4,13 @@ nextflow_process {
     script "main.nf"
     process "TEST_PUBLISH_FOLDER"
 
-    test("Should run without failures") {
+    test("TEST_PUBLISH_FOLDER") {
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_publish_folder.nf.test.snap
+++ b/tests/main.test_publish_folder.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Should run without failures": {
+    "TEST_PUBLISH_FOLDER": {
         "content": [
             {
                 "0": [
@@ -10,6 +10,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-10-04T11:56:26.981311"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-18T17:19:30.136869"
     }
 }

--- a/tests/main.test_stage_remote.test
+++ b/tests/main.test_stage_remote.test
@@ -4,7 +4,7 @@ nextflow_process {
     script "main.nf"
     process "TEST_STAGE_REMOTE"
 
-    test("Should run without failures") {
+    test("TEST_STAGE_REMOTE") {
 
         when {
 
@@ -20,8 +20,10 @@ nextflow_process {
         }
 
         then {
-            assert process.success
-            assert snapshot(process.out).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
         }
 
     }

--- a/tests/main.test_success.nf.test
+++ b/tests/main.test_success.nf.test
@@ -4,13 +4,15 @@ nextflow_process {
     script "main.nf"
     process "TEST_SUCCESS"
 
-    test("Should run without failures") {
+    test("TEST_SUCCESS") {
 
         then {
-            assert process.success
-            assert process.exitStatus == 0
-            assert process.trace.tasks().size() == 1
-            assert snapshot(process).match()
+            assertAll(
+                { assert process.success },
+                { assert process.exitStatus == 0 },
+                { assert process.trace.tasks().size() == 1 },
+                { assert snapshot(process).match() }
+            )
         }
 
     }

--- a/tests/main.test_success.nf.test.snap
+++ b/tests/main.test_success.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Should run without failures": {
+    "TEST_SUCCESS": {
         "content": [
             {
                 "stderr": [
@@ -26,6 +26,10 @@
                 "success": true
             }
         ],
-        "timestamp": "2023-10-04T12:20:24.512086"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-18T17:19:40.583688"
     }
 }


### PR DESCRIPTION
The nf-tests were a bit untidy and used assert statements where they should have used assertAll statements.
