### PR TITLE
Make container image configurable via parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Configure your infrastructure using the appropriate configuration files listed i
 
 nf-canary adheres to the `--outdir` convention established by [nf-core](https://nf-co.re/) to determine the output file destination. If not specified, output files are written to the work directory under a subfolder named `outputs`.
 
+### Overriding default container
+
+The param `container` is used to specify the container used to run the pipeline.
+By default it is using `ubuntu:24.04` hosted by `biocontainers` on `quay.io`.
+This can be overridden by changing the `container` param.
+
+```nextflow
+params.container = 'docker.io/ubuntu:24.04'
+```
+
 ### Skipping Tests
 
 Skip individual tests by name using the `--skip` parameter, e.g., `--skip TEST_INPUT`. Multiple tests can be specified with comma-delimited values, e.g., `--skip TEST_CREATE_FILE,TEST_PASS_FILE`. The parameter is case-insensitive.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ nf-canary adheres to the `--outdir` convention established by [nf-core](https://
 
 ### Overriding default container
 
-The param `container` is used to specify the container used to run the pipeline.
-By default it is using `ubuntu:24.04` hosted by `biocontainers` on `quay.io`.
-This can be overridden by changing the `container` param.
+The container is specified by the `container` parameter, which defaults to `quay.io/biocontainers/ubuntu:24.04`. If you wish to use a different container, you can specify an alternative using the --container parameter.
 
 ```nextflow
 params.container = 'docker.io/ubuntu:24.04'

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,6 +4,7 @@ params {
     run        = null
     outdir     = null
     remoteFile = null
+    container  = "quay.io/biocontainers/ubuntu:24.04"
 }
 
 process {

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,7 @@ params {
 }
 
 process {
-    container     = "docker.io/library/ubuntu:23.10"
+    container     = "quay.io/biocontainers/ubuntu:24.04"
     errorStrategy = "finish"
     when          = { 
         ( params.run ? params.run.split(',').any{ "NF_CANARY:${it.toUpperCase()}".contains(task.process) } : true ) && 

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,7 +8,7 @@ params {
 }
 
 process {
-    container     = "quay.io/biocontainers/ubuntu:24.04"
+    container     = params.container
     errorStrategy = "finish"
     when          = { 
         ( params.run ? params.run.split(',').any{ "NF_CANARY:${it.toUpperCase()}".contains(task.process) } : true ) && 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -30,7 +30,7 @@
                 "container": {
                     "type": "string",
                     "description": "Container URI for nf-canary",
-                    "help_text": "URI for container. By default this is a ubuntu container on quay.io that should not have any hit limit.",
+                    "help_text": "Specifies the container URI. By default, this is an Ubuntu container on quay.io with no usage limits.",
                     "default": "quay.io/biocontainers/ubuntu:24.04"
                 },
                 "gpu": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -27,6 +27,12 @@
                     "help_text": "Path to a remote file to use within the pipeline. This mimics a remote set of files such as reference data that may need to be retrieved prior to analysis. By default this is not specified and the test is not ran, add a remote file using standard Nextflow filenaming to pull a file from your storage (e.g. an S3 bucket or shared storage).",
                     "format": "path"
                 },
+                "container": {
+                    "type": "string",
+                    "description": "Container URI for nf-canary",
+                    "help_text": "URI for container. By default this is a ubuntu container on quay.io that should not have any hit limit.",
+                    "default": "quay.io/biocontainers/ubuntu:24.04"
+                },
                 "gpu": {
                     "type": "boolean",
                     "description": "Whether to test GPU utilization within a process."


### PR DESCRIPTION
docker.io has very limited free tier usage. Therefore this pipeline fails because it is unable to pull images from dockerhub unless credentials are supplied. 

This PR switches to using quay.io which has much higher limits and is therefore easier to use out of the box.

It also switches ubuntu from version 23.10 to 24.04.

Closes https://github.com/seqeralabs/nf-canary/issues/32